### PR TITLE
Fix extra curl_close() PHP warning.

### DIFF
--- a/curlexample.php
+++ b/curlexample.php
@@ -14,9 +14,6 @@
 
         // close curl resource to free up system resources
         curl_close($ch);
-        
-        // close curl resource to free up system resources
-        curl_close($ch);
 
         //Get the public IP address
         echo "The public IP address for your EC2 instance is $output";


### PR DESCRIPTION
Just a trivial fix here, otherwise a PHP warning ensues; e.g.

```
[root@ip-172-31-16-192 metadata]# php curlexample.php 
PHP Warning:  curl_close(): 4 is not a valid cURL handle resource in /var/www/html/metadata/curlexample.php on line 19
```
